### PR TITLE
Stabilize BPS lifecycle, entity IDs, and tracker icon support

### DIFF
--- a/.cursor/rules/bps-homeassistant.mdc
+++ b/.cursor/rules/bps-homeassistant.mdc
@@ -1,0 +1,20 @@
+---
+description: BPS Home Assistant integration rules
+alwaysApply: true
+---
+
+This repository is a Home Assistant custom integration installed through HACS.
+
+Rules:
+- Work on dev or feature branches, never directly on main.
+- Do not change manifest.json version unless preparing a release.
+- Before changing code, inspect the existing implementation.
+- Keep changes small and isolated.
+- Preserve HACS compatibility.
+- Preserve existing config entries and entity IDs.
+- When fixing a bug, add or update tests if practical.
+- Before finalizing, run or ask the user to run:
+  - python -m pytest
+  - ruff check .
+- Do not implement pull request changes automatically. First summarize and ask for approval.
+- Do not treat forum comments as confirmed bugs unless reproducible or consistent with issues/logs.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+**/.DS_Store
+.cursor/context/

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -519,17 +519,23 @@ class BPSMapsListAPI(HomeAssistantView):
     name = "api:bps:maps"
     requires_auth = False
 
+    @staticmethod
+    def _list_map_files(maps_path):
+        """List map file names from disk (runs in executor)."""
+        with os.scandir(maps_path) as entries:
+            return [
+                entry.name
+                for entry in entries
+                if entry.is_file() and entry.name.lower().endswith((".png", ".jpg"))
+            ]
+
     async def get(self, request):
         """Return a list of map files as JSON."""
         hass = request.app["hass"]
         maps_path = hass.config.path("www/bps_maps")
 
         try:
-            files = [
-                f for f in os.scandir(maps_path) 
-                if f.is_file() and f.name.lower().endswith(('.png', '.jpg'))
-            ]
-            file_names = [f.name for f in files]
+            file_names = await hass.async_add_executor_job(self._list_map_files, maps_path)
             return web.json_response(file_names)
         except Exception as e:
             _LOGGER.error(f"Error listing map files: {e}")

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -378,6 +378,10 @@ async def async_unload_entry(hass: HomeAssistant, entry):
         _LOGGER.error(f"Error when removing frontend-panel for entry {entry.entry_id}: {e}")
         return False
 
+    # Allow clean setup after integration reload/removal.
+    hass.data.pop("bps_initialized", None)
+    hass.data.pop("bps_sensors", None)
+
     return True
 
 

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -16,6 +16,8 @@ import logging
 import asyncio
 import os
 import json
+import re
+import copy
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from shapely.geometry import Point, Polygon
@@ -26,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "bps"
 OPTION_SHOW_SIDEBAR_PANEL = "show_sidebar_panel"
 FRONTEND_PATH = Path(__file__).parent / "frontend"
+LEGACY_BPS_ENTITY_PATTERN = re.compile(r"^sensor\.(.+)_\1_bps_(zone|floor)$")
 
 # Global data
 global_data = []
@@ -37,6 +40,28 @@ tracked_entities = []
 new_global_data = {}
 secToUpdate = 1
 apitricords = []
+
+
+def cleanup_legacy_bps_registry_and_states(hass: HomeAssistant):
+    """Remove legacy duplicated BPS ids from entity registry and state machine."""
+    entity_registry = er.async_get(hass)
+    legacy_registry_ids = [
+        entry.entity_id
+        for entry in entity_registry.entities.values()
+        if LEGACY_BPS_ENTITY_PATTERN.match(entry.entity_id)
+    ]
+    for entity_id in legacy_registry_ids:
+        _LOGGER.info("Removing legacy BPS registry entity: %s", entity_id)
+        entity_registry.async_remove(entity_id)
+
+    legacy_state_ids = [
+        state.entity_id
+        for state in hass.states.async_all()
+        if LEGACY_BPS_ENTITY_PATTERN.match(state.entity_id)
+    ]
+    for entity_id in legacy_state_ids:
+        _LOGGER.info("Removing legacy BPS state: %s", entity_id)
+        hass.states.async_remove(entity_id)
 
 class FileWatcher(FileSystemEventHandler):
     """A class to handle file changes"""
@@ -103,7 +128,8 @@ async def update_tracked_entities(hass, jinja_code):
             
             cleaned = [item.split("_distance_to_")[0].replace("sensor.", "") for item in tracked_entities]
             unique_values = list(set(cleaned))
-            new_global_data = [{"entity": ent, "data": global_data} for ent in unique_values]
+            # Use a separate copy per entity to avoid cross-entity mutation side effects.
+            new_global_data = [{"entity": ent, "data": copy.deepcopy(global_data)} for ent in unique_values]
             
             await process_entities(hass, new_global_data)
 
@@ -180,8 +206,8 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
         zone = find_zone_for_point(new_global_data, entity, lowest_floor_name, test_point)
         apitricords = update_or_add_entry(apitricords, {"ent": entity, "cords": [avg_x, avg_y], "zone": zone})
         await update_apitricords(hass, apitricords)
-        hass.states.async_set(f"sensor.{entity}_bps_zone", zone)
-        hass.states.async_set(f"sensor.{entity}_bps_floor", lowest_floor_name)
+        update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)
+        update_bps_sensor_state(hass, f"sensor.{entity}_bps_floor", lowest_floor_name)
 
 def update_or_add_entry(data, new_entry):
     for item in data:
@@ -198,6 +224,18 @@ async def update_apitricords(hass, new_data):
     """Update apitricords in hass.data"""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN]["apitricords"] = new_data
+
+
+def update_bps_sensor_state(hass, entity_id, state):
+    """Update state on registered BPS SensorEntity instead of raw hass state."""
+    sensors_cache = hass.data.get("bps_sensors")
+    if not sensors_cache:
+        return
+    sensor = sensors_cache.get(entity_id)
+    if sensor is None:
+        return
+    sensor._state = state
+    sensor.async_write_ha_state()
 
 async def process_single_entity(hass, new_global_data, eids):
     """Process a single entity: first receivers, then trilateration"""
@@ -345,7 +383,14 @@ async def async_setup(hass, config):
 
         await update_global_data(target_file)
 
+        # Stop any previous watcher before creating a new one on reload.
+        old_observer = hass.data.get("bps_observer")
+        if old_observer:
+            old_observer.stop()
+            old_observer.join(timeout=2)
+
         observer = setup_file_watcher(target_file, lambda: update_global_data(target_file), hass)
+        hass.data["bps_observer"] = observer
 
         jinja_code = """
         {{
@@ -357,7 +402,10 @@ async def async_setup(hass, config):
         }}
         """
 
-        hass.async_create_task(update_tracked_entities(hass, jinja_code))
+        old_task = hass.data.get("bps_update_task")
+        if old_task:
+            old_task.cancel()
+        hass.data["bps_update_task"] = hass.async_create_task(update_tracked_entities(hass, jinja_code))
 
         hass.bus.async_listen_once("homeassistant_stop", lambda event: observer.stop())
 
@@ -377,6 +425,12 @@ async def async_setup(hass, config):
 async def async_unload_entry(hass: HomeAssistant, entry):
     """Remove a configuration entry"""
     _LOGGER.info("Attempting to offload platforms for entry: %s", entry.entry_id)
+
+    state_listener_unsub = hass.data.pop("bps_state_listener_unsub", None)
+    if state_listener_unsub:
+        state_listener_unsub()
+
+    cleanup_legacy_bps_registry_and_states(hass)
 
     entity_registry = er.async_get(hass)
 
@@ -407,6 +461,24 @@ async def async_unload_entry(hass: HomeAssistant, entry):
         _LOGGER.error(f"Error when removing frontend-panel for entry {entry.entry_id}: {e}")
         return False
 
+    observer = hass.data.pop("bps_observer", None)
+    if observer:
+        observer.stop()
+        observer.join(timeout=2)
+
+    update_task = hass.data.pop("bps_update_task", None)
+    if update_task:
+        update_task.cancel()
+
+    # Remove BPS states from the state machine when integration is unloaded.
+    bps_state_ids = [
+        state.entity_id
+        for state in hass.states.async_all()
+        if state.entity_id.startswith("sensor.") and state.entity_id.endswith(("_bps_zone", "_bps_floor"))
+    ]
+    for entity_id in bps_state_ids:
+        hass.states.async_remove(entity_id)
+
     # Allow clean setup after integration reload/removal.
     hass.data.pop("bps_initialized", None)
     hass.data.pop("bps_sensors", None)
@@ -417,6 +489,7 @@ async def async_unload_entry(hass: HomeAssistant, entry):
 async def async_setup_entry(hass, entry):
     """Set the integration from a configuration entry"""
     _LOGGER.info("async_setup_entry har anropats")
+    cleanup_legacy_bps_registry_and_states(hass)
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
@@ -564,7 +637,7 @@ class BPSMapsListAPI(HomeAssistantView):
             return [
                 entry.name
                 for entry in entries
-                if entry.is_file() and entry.name.lower().endswith((".png", ".jpg"))
+                if entry.is_file() and entry.name.lower().endswith((".png", ".jpg", ".jpeg", ".webp"))
             ]
 
     async def get(self, request):

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -91,8 +91,12 @@ async def update_tracked_entities(hass, jinja_code):
             tracked_entities = template.async_render()
 
             num_points = len(tracked_entities)
-            if num_points < 3: # There are no devices close enough to track, wait 10 seconds until try again
+            if num_points == 0:
                 _LOGGER.info("There are no devices present to track, sleep 10 seconds")
+                await asyncio.sleep(10)
+                continue  # Skip and start over
+            if num_points < 3:
+                _LOGGER.info("There are not enough trackers with available data to track, sleep 10 seconds")
                 await asyncio.sleep(10)
                 continue  # Skip and start over
             
@@ -335,7 +339,6 @@ async def async_setup(hass, config):
         {{
             expand(states.sensor)
             | selectattr("entity_id", "search", "_distance_to_")
-            | selectattr("state", "is_number")
             | map(attribute="entity_id")
             | unique
             | list

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -24,6 +24,7 @@ from asyncio import Lock, Queue, wait_for, TimeoutError
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bps"
+OPTION_SHOW_SIDEBAR_PANEL = "show_sidebar_panel"
 FRONTEND_PATH = Path(__file__).parent / "frontend"
 
 # Global data
@@ -304,22 +305,33 @@ async def async_setup(hass, config):
             _LOGGER.error(f"Could not create the folder {target_dir}: {e}")
             return
 
+        show_sidebar_panel = True
+        if hasattr(config, "options"):
+            show_sidebar_panel = config.options.get(OPTION_SHOW_SIDEBAR_PANEL, True)
+        else:
+            entries = hass.config_entries.async_entries(DOMAIN)
+            if entries:
+                show_sidebar_panel = entries[0].options.get(OPTION_SHOW_SIDEBAR_PANEL, True)
         panels = hass.data.get("frontend_panels", {})
         if "bps" in panels:
             async_remove_panel(hass, "bps")
-        try:
-            _LOGGER.debug("Registering the built-in panel for BPS...")
-            async_register_built_in_panel(
-                hass=hass,
-                component_name="iframe",
-                sidebar_title="BPS",
-                sidebar_icon="mdi:map",
-                frontend_url_path="bps",
-                config={"url": "/bps/index.html"},
-            )
-            _LOGGER.info("Panel registered successfully.")
-        except Exception as e:
-            _LOGGER.error(f"Failed to register panel: {e}")
+
+        if show_sidebar_panel:
+            try:
+                _LOGGER.debug("Registering the built-in panel for BPS...")
+                async_register_built_in_panel(
+                    hass=hass,
+                    component_name="iframe",
+                    sidebar_title="BPS",
+                    sidebar_icon="mdi:map",
+                    frontend_url_path="bps",
+                    config={"url": "/bps/index.html"},
+                )
+                _LOGGER.info("Panel registered successfully.")
+            except Exception as e:
+                _LOGGER.error(f"Failed to register panel: {e}")
+        else:
+            _LOGGER.info("BPS sidebar panel is disabled by integration options.")
 
         try:
             if not os.path.exists(target_file):
@@ -406,9 +418,15 @@ async def async_setup_entry(hass, entry):
     """Set the integration from a configuration entry"""
     _LOGGER.info("async_setup_entry har anropats")
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     """Set up BPS from a config entry."""
     return await async_setup(hass, entry)
+
+
+async def async_update_options(hass, entry):
+    """Reload integration when options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 class BPSFrontendView(HomeAssistantView):
     """Serve the frontend files."""
@@ -416,7 +434,6 @@ class BPSFrontendView(HomeAssistantView):
     url = "/bps/{file_name}"
     name = "bps:frontend"
     requires_auth = False
-    #requires_auth = True
 
     async def get(self, request, file_name):
         """Serve static files from the frontend folder."""
@@ -567,7 +584,7 @@ class BPSCordsAPI(HomeAssistantView):
 
     url = "/api/bps/cords"
     name = "api:bps:cords"
-    requires_auth = False  # Ändra till True om du vill kräva autentisering
+    requires_auth = False
 
     def __init__(self, hass):
         """Spara referens till hass"""

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -323,6 +323,8 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSFrontendView())
             hass.http.register_view(BPSSaveAPIText())
             hass.http.register_view(BPSMapsListAPI())
+            hass.http.register_view(BPSTrackerIconsListAPI())
+            hass.http.register_view(BPSUploadTrackerIconAPI())
             hass.http.register_view(BPSReadAPIText())
             hass.http.register_view(BPSCordsAPI(hass))
             hass.data["bps_views_registered"] = True
@@ -334,6 +336,7 @@ async def async_setup(hass, config):
 
         config_path = hass.config.path()
         target_dir = os.path.join(config_path, "www", "bps_maps")
+        tracker_icons_dir = os.path.join(config_path, "www", "bps_icons")
         target_file = os.path.join(target_dir, "bpsdata.txt")
 
         try:
@@ -341,6 +344,13 @@ async def async_setup(hass, config):
             _LOGGER.info(f"Folder {target_dir} has been created or already existed")
         except Exception as e:
             _LOGGER.error(f"Could not create the folder {target_dir}: {e}")
+            return
+
+        try:
+            await aiofiles.os.makedirs(tracker_icons_dir, exist_ok=True)
+            _LOGGER.info(f"Folder {tracker_icons_dir} has been created or already existed")
+        except Exception as e:
+            _LOGGER.error(f"Could not create the folder {tracker_icons_dir}: {e}")
             return
 
         show_sidebar_panel = True
@@ -651,7 +661,75 @@ class BPSMapsListAPI(HomeAssistantView):
         except Exception as e:
             _LOGGER.error(f"Error listing map files: {e}")
             return web.Response(status=500, text="Error listing map files")
-        
+
+
+class BPSTrackerIconsListAPI(HomeAssistantView):
+    """API to list tracker icon files."""
+
+    url = "/api/bps/tracker_icons"
+    name = "api:bps:tracker_icons"
+    requires_auth = False
+
+    @staticmethod
+    def _list_tracker_icons(icons_path):
+        if not os.path.isdir(icons_path):
+            return []
+        with os.scandir(icons_path) as entries:
+            return [
+                {"value": f"/local/bps_icons/{entry.name}", "label": entry.name}
+                for entry in entries
+                if entry.is_file() and entry.name.lower().endswith((".png", ".jpg", ".jpeg", ".webp", ".svg"))
+            ]
+
+    async def get(self, request):
+        hass = request.app["hass"]
+        icons_path = hass.config.path("www/bps_icons")
+        try:
+            custom_icons = await hass.async_add_executor_job(self._list_tracker_icons, icons_path)
+            defaults = [
+                {"value": "/bps/person.svg", "label": "Person (default)"},
+                {"value": "/bps/beacon.svg", "label": "Beacon"},
+            ]
+            return web.json_response(defaults + custom_icons)
+        except Exception as e:
+            _LOGGER.error(f"Error listing tracker icons: {e}")
+            return web.Response(status=500, text="Error listing tracker icons")
+
+
+class BPSUploadTrackerIconAPI(HomeAssistantView):
+    """API to upload custom tracker icons."""
+
+    url = "/api/bps/upload_tracker_icon"
+    name = "api:bps:upload_tracker_icon"
+    requires_auth = False
+
+    async def post(self, request):
+        hass = request.app["hass"]
+        data = await request.post()
+        icon_file = data.get("icon")
+        if not icon_file:
+            return web.Response(status=400, text="Missing icon")
+
+        safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", Path(icon_file.filename).name)
+        if not safe_name:
+            return web.Response(status=400, text="Invalid filename")
+
+        icons_path = hass.config.path("www/bps_icons")
+        try:
+            await aiofiles.os.makedirs(icons_path, exist_ok=True)
+            target_path = Path(icons_path) / safe_name
+            async with aiofiles.open(target_path, "wb") as f:
+                await f.write(icon_file.file.read())
+        except Exception as e:
+            _LOGGER.error(f"Failed to upload tracker icon: {e}")
+            return web.Response(status=500, text="Failed to upload icon")
+
+        return web.json_response({
+            "icon_url": f"/local/bps_icons/{safe_name}",
+            "icon_name": safe_name,
+        })
+
+
 class BPSCordsAPI(HomeAssistantView):
     """API för att skicka tillbaka apitricords"""
 

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -253,7 +253,7 @@ async def async_setup(hass, config):
     _LOGGER.info("BPS integration initierad.")
 
     if hass.data.get("bps_initialized", False):
-        _LOGGER.warning("BPS has already been initialized. Aborting")
+        _LOGGER.debug("BPS already initialized in current runtime; skipping duplicate init.")
         return True  # Abort if already running
 
     hass.data["bps_initialized"] = True  # Set flag

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -225,18 +225,32 @@ def find_zone_for_point(data, entity, floor_name, point):
     """Find zone for point, prioritize correct polygon, select nearest buffer if no correct zone matches."""
     buffer_percent = 0.05  # set to 5%
     buffer_candidates = []
+
+    def order_zone_points(coords):
+        """Order polygon points clockwise around centroid to avoid self-intersections."""
+        if len(coords) < 3:
+            return coords
+        center_x = sum(coord["x"] for coord in coords) / len(coords)
+        center_y = sum(coord["y"] for coord in coords) / len(coords)
+        return sorted(
+            coords,
+            key=lambda coord: np.arctan2(coord["y"] - center_y, coord["x"] - center_x)
+        )
+
     for entity_data in data:
         if entity_data["entity"] == entity:
             for floor in entity_data["data"]["floor"]:
                 if floor["name"] == floor_name:
                     for zone in floor["zones"]:
-                        polygon = Polygon([(coord["x"], coord["y"]) for coord in zone["cords"]])
-                        xs = [coord["x"] for coord in zone["cords"]]
-                        ys = [coord["y"] for coord in zone["cords"]]
+                        ordered_coords = order_zone_points(zone["cords"])
+                        polygon = Polygon([(coord["x"], coord["y"]) for coord in ordered_coords])
+                        xs = [coord["x"] for coord in ordered_coords]
+                        ys = [coord["y"] for coord in ordered_coords]
                         width = max(xs) - min(xs)
                         height = max(ys) - min(ys)
                         buffer_size = ((width + height) / 2) * buffer_percent
-                        if polygon.contains(point):
+                        # covers() also matches points on the polygon boundary.
+                        if polygon.covers(point):
                             return zone["entity_id"]  # Prioritize correct polygon
                         elif polygon.buffer(buffer_size).contains(point):
                             # Save candidate: (distance to edge, entity_id)

--- a/custom_components/bps/config_flow.py
+++ b/custom_components/bps/config_flow.py
@@ -22,7 +22,6 @@ class BPSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        if user_input is not None:
-            return self.async_create_entry(title="BLE Positioning System", data={})
-
-        return self.async_show_form(step_id="user")
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title="BLE Positioning System", data={})

--- a/custom_components/bps/config_flow.py
+++ b/custom_components/bps/config_flow.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+OPTION_SHOW_SIDEBAR_PANEL = "show_sidebar_panel"
 
 # Definiera vilka inställningar användaren kan ange
 CONFIG_SCHEMA = vol.Schema(
@@ -25,3 +26,27 @@ class BPSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="BLE Positioning System", data={})
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Create the options flow."""
+        return BPSOptionsFlow(config_entry)
+
+
+class BPSOptionsFlow(config_entries.OptionsFlow):
+    """Handle BPS options."""
+
+    def __init__(self, config_entry):
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the BPS options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current_value = self._config_entry.options.get(OPTION_SHOW_SIDEBAR_PANEL, True)
+        schema = vol.Schema({
+            vol.Required(OPTION_SHOW_SIDEBAR_PANEL, default=current_value): bool,
+        })
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -34,6 +34,14 @@
                 <select id="entSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
                     <option value="">--Please choose an option--</option>
                 </select>
+                <select id="trackerIconSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                    <option value="/bps/person.svg">Person</option>
+                    <option value="/bps/beacon.svg">Beacon</option>
+                </select>
+                <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                <button type="button" id="uploadTrackerIcon" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                    Upload tracker icon
+                </button>
                 <div class="flex gap-2 items-center p-1">
                     <input type="checkbox" id="myCheckbox">
                     <label style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="myCheckbox">Real time track</label>

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -38,7 +38,7 @@
                     <input type="checkbox" id="myCheckbox">
                     <label style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="myCheckbox">Real time track</label>
                     <span class="tooltip">❓
-                        <span class="tooltip-text">To use realt time tracking, Long-lived token and hassURL needs to be added! Read the docs for more info.</span>
+                        <span class="tooltip-text">Real time tracking uses your current Home Assistant session.</span>
                     </span>
                 </div>
                 <button style="display: none" type="button" id="starttrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const circles = [];
     let receiverName = "";
     let zoneName = "";
+    const createZoneId = () => `zone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let isDrawing = false;
     let SelMapName = "";
     let new_floor = true;
@@ -524,10 +525,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 console.log(`Zone with ID "${idToRemove}" was not found.`);
                 return;
             }
-            // Loop through each floor and remove zones where the entity_id matches
+            // Loop through each floor and remove zones where the internal zone id matches
             finalcords.floor.forEach(floor => {
                 if (floor.name === SelMapName) {
-                    floor.zones = floor.zones.filter(zone => zone.entity_id !== idToRemove);
+                    floor.zones = floor.zones.filter(zone => (zone.zone_id || zone.entity_id) !== idToRemove);
                 }
             });
             console.log("Removed zone");
@@ -633,6 +634,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 { x: rectangle.x + rectangle.width, y: rectangle.y + rectangle.height }
             ];
             let newZone = {
+                zone_id: createZoneId(),
                 entity_id: zoneName,
                 cords: zonecords
               }; 
@@ -1039,7 +1041,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 tmpname = receiverName;
             }
             if(dataType === "zones"){
-                enitityExists = floor[dataType].some(zone => zone.entity_id === zoneName);
+                // Allow multiple zones with the same display name.
+                enitityExists = false;
                 tmpname = zoneName;
             }
             if(dataType === "scale"){
@@ -1122,6 +1125,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
             // Loopa through all zones in floor
             floor.zones.forEach((zone, index) => {
+                if (!zone.zone_id) {
+                    zone.zone_id = createZoneId();
+                }
                 zone.type = "zone";
                 tmpdrawcords.push(zone);
             });
@@ -1166,7 +1172,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ctx.fillStyle = "red";
                 ctx.fillText(item.entity_id, x + 10, y + iconSize / 4);
                 if(item.entity_id){
-                    tmpHTMLzone = tmpHTMLzone + newelement.replace("typename", item.entity_id).replace("removexxx", "removezone").replace("idxxx", item.entity_id).replace("idxxx", item.entity_id);
+                    const zoneDomId = item.zone_id || item.entity_id;
+                    tmpHTMLzone = tmpHTMLzone + newelement.replace("typename", item.entity_id).replace("removexxx", "removezone").replace("idxxx", zoneDomId).replace("idxxx", zoneDomId);
                 }
             }
         });

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const upload = document.getElementById('upload');
     const mapSelector = document.getElementById('mapSelector');
     const entSelector = document.getElementById('entSelector');
+    const trackerIconSelector = document.getElementById('trackerIconSelector');
+    const trackerIconUpload = document.getElementById('trackerIconUpload');
+    const uploadTrackerIconButton = document.getElementById('uploadTrackerIcon');
     const mapbuttondiv = document.getElementById('mapbuttondiv');
     const savebuttondiv = document.getElementById('savebuttondiv');
     const trackdiv = document.getElementById('trackdiv');
@@ -46,6 +49,73 @@ document.addEventListener('DOMContentLoaded', async () => {
     let imgfilename = "";
     let device = "";
     let myScaleVal = null;
+    const DEFAULT_TRACKER_ICON = "/bps/person.svg";
+
+    function ensureTrackerIconsStore() {
+        if (!finalcords.tracker_icons || typeof finalcords.tracker_icons !== "object") {
+            finalcords.tracker_icons = {};
+        }
+    }
+
+    function getTrackerEntityKey() {
+        return device.replace("sensor.", "");
+    }
+
+    function getSelectedTrackerIcon() {
+        ensureTrackerIconsStore();
+        const trackerKey = getTrackerEntityKey();
+        const storedIcon = finalcords.tracker_icons[trackerKey];
+        if (storedIcon === "person.svg") {
+            return "/bps/person.svg";
+        }
+        if (storedIcon === "beacon.svg") {
+            return "/bps/beacon.svg";
+        }
+        return storedIcon || DEFAULT_TRACKER_ICON;
+    }
+
+    function ensureIconOption(value, label = null) {
+        if (!trackerIconSelector) {
+            return;
+        }
+        if (!value) {
+            return;
+        }
+        const existing = Array.from(trackerIconSelector.options).find(option => option.value === value);
+        if (existing) {
+            if (label) {
+                existing.textContent = label;
+            }
+            return;
+        }
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = label || value;
+        trackerIconSelector.appendChild(option);
+    }
+
+    async function loadTrackerIcons() {
+        if (!trackerIconSelector) {
+            return;
+        }
+        // Keep defaults available even if API call fails.
+        ensureIconOption("/bps/person.svg", "Person (default)");
+        ensureIconOption("/bps/beacon.svg", "Beacon");
+        try {
+            const response = await fetch("/api/bps/tracker_icons");
+            if (!response.ok) {
+                return;
+            }
+            const icons = await response.json();
+            icons.forEach(icon => {
+                if (icon && icon.value) {
+                    ensureIconOption(icon.value, icon.label || icon.value);
+                }
+            });
+        } catch (error) {
+            console.error("Failed loading tracker icons:", error);
+        }
+    }
 
     const newelement = `
                 <ul class="space-y-2" id="idxxx">
@@ -85,6 +155,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         
     
         // Once the maps are loaded, call fetchBPSData
+        await loadTrackerIcons();
         let tmpsaved = await getSavedMaps();
         if (tmpsaved){
             fetchBPSData();
@@ -377,7 +448,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const x = tricords.x;
         const y = tricords.y;
         const icon = new Image();
-        icon.src = "person.svg";
+        icon.src = getSelectedTrackerIcon();
         icon.onload = () => {
             ctx.drawImage(icon, x - iconSize / 2, y - iconSize / 2, iconSize, iconSize);
         };
@@ -401,6 +472,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const data = await response.json();
         
             finalcords = JSON.parse(data.coordinates);
+            ensureTrackerIconsStore();
             tmpfinalcords = finalcords; //Store original cords in a temp to compare later if it is changed
             console.log("Coordinates loaded:", finalcords);
             let ents = data.entities;
@@ -450,11 +522,69 @@ document.addEventListener('DOMContentLoaded', async () => {
                     stoptrackstat = true;
                 }
                 device = "sensor."+entSelector.value;
+                const selectedIcon = getSelectedTrackerIcon();
+                if (trackerIconSelector) {
+                    ensureIconOption(selectedIcon);
+                    trackerIconSelector.value = selectedIcon;
+                }
                 starttrackbtn.style.display = "";
             } else {
                 starttrackbtn.style.display = "none";
             }
         });
+
+        if (trackerIconSelector) {
+            trackerIconSelector.addEventListener("change", () => {
+                if (!device) {
+                    return;
+                }
+                ensureTrackerIconsStore();
+                finalcords.tracker_icons[getTrackerEntityKey()] = trackerIconSelector.value;
+                savebuttondiv.appendChild(saveButton);
+            });
+        }
+
+        if (uploadTrackerIconButton && trackerIconUpload) {
+            uploadTrackerIconButton.addEventListener("click", async () => {
+                if (!device) {
+                    alert("Choose tracker first.");
+                    return;
+                }
+                const iconFile = trackerIconUpload.files[0];
+                if (!iconFile) {
+                    alert("Choose an icon file first.");
+                    return;
+                }
+                const uploadData = new FormData();
+                uploadData.append("icon", iconFile);
+                try {
+                    const response = await fetch("/api/bps/upload_tracker_icon", {
+                        method: "POST",
+                        body: uploadData,
+                    });
+                    if (!response.ok) {
+                        alert("Could not upload icon.");
+                        return;
+                    }
+                    const payload = await response.json();
+                    if (!payload || !payload.icon_url) {
+                        alert("Could not upload icon.");
+                        return;
+                    }
+                    ensureIconOption(payload.icon_url, payload.icon_name || payload.icon_url);
+                    if (trackerIconSelector) {
+                        trackerIconSelector.value = payload.icon_url;
+                    }
+                    ensureTrackerIconsStore();
+                    finalcords.tracker_icons[getTrackerEntityKey()] = payload.icon_url;
+                    savebuttondiv.appendChild(saveButton);
+                    alert("Tracker icon uploaded. Click Save Floor Plan to persist.");
+                } catch (error) {
+                    console.error("Icon upload failed:", error);
+                    alert("Could not upload icon.");
+                }
+            });
+        }
     
     
     // Check if the image is loaded in the canvas

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1,15 +1,3 @@
-//Create a long-lived token
-//Click on you user in the bottom left corner
-//Click on security on the top of the page
-//In the bottom of the page, create a new token. The name does not matter
-//Copy the token and below
-//Example: const hass_token = "my_secret_token";
-const hass_token = "";
-// Add your url that you use in your browser
-//Example1: const hassURL = "xxx.duckdns.org";
-//Example2: const hassURL = "192.168.0.10:8123";
-const hassURL = "";
-
 document.addEventListener('DOMContentLoaded', async () => {
     const canvas = document.getElementById('canvas');
     const ctx = canvas.getContext('2d');
@@ -102,9 +90,35 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         let socket = null;
+        let hassConnection = null;
+        let socketMessageHandler = null;
+        let bpsSubscribeId = null;
         const tracked = [];
         let NewEnts = [];
         let socketIdCounter = 1; 
+
+        async function getHAConnection() {
+            if (hassConnection && hassConnection.socket) {
+                return hassConnection;
+            }
+
+            const parentConnection = window.parent && window.parent.hassConnection;
+            const localConnection = window.hassConnection;
+            const connectionPromise = parentConnection || localConnection;
+
+            if (!connectionPromise) {
+                return null;
+            }
+
+            const connectionObject = await connectionPromise;
+            hassConnection = connectionObject.conn || connectionObject;
+
+            if (!hassConnection || !hassConnection.socket) {
+                return null;
+            }
+
+            return hassConnection;
+        }
 
         function startTracking() {
             if (!checkCanvasImage()) return;
@@ -114,23 +128,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             if (socket){
                 alert("Already active connection");
-                return;
-            }
-
-            if (!hass_token || !hassURL){
-                let messageStr = "";
-                if (!hass_token){
-                    messageStr = "You have to add a long-lived token";
-                }
-                if (!hass_token && !hassURL){
-                    messageStr = messageStr+" and the hassURL. Please read the instructions!";
-                    alert(messageStr);
-                    return;
-                }
-                if (!hassURL){
-                    messageStr = "You have to add the hassURL";
-                }
-                alert(messageStr);
                 return;
             }
             
@@ -150,28 +147,24 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return;
             }
     
-            console.log("open socket");
-            socket = new WebSocket("wss://"+hassURL+"/api/websocket");
-            socket.onopen = () => {
-                // Send authentication
-                console.log("sending auth");
-                socket.send(JSON.stringify({ type: "auth", access_token: hass_token }));
-    
-                // Once authentication is complete, subscribe
-                socket.onmessage = async (event) => {
-                    let message = JSON.parse(event.data);
-                    if (message.type === "auth_ok") {
-                        console.log("auth ok");
-                        starttrackbtn.style.display = "none";
-                        stoptrackbtn.style.display = "";
-                        // Subscribe to entiteter
-                        socket.send(JSON.stringify({
-                            id: 1, // Unique ID for this message
-                            type: "bps/subscribe",
-                            entities: tracked,
-                        }));
+            getHAConnection().then((conn) => {
+                if (!conn) {
+                    alert("Could not access Home Assistant connection.");
+                    return;
+                }
+
+                socket = conn.socket;
+                bpsSubscribeId = Date.now();
+                socketIdCounter = bpsSubscribeId;
+
+                socketMessageHandler = async (event) => {
+                    let message = null;
+                    try {
+                        message = JSON.parse(event.data);
+                    } catch (e) {
+                        return;
                     }
-            
+
                     if (message.type === "state_changed") {
                         await updateEntArray(message.entity_id, message.new_state);
                         socketIdCounter++;
@@ -189,7 +182,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     } else if (message.type === "tri_result" && !message.success) {
                         console.log("Tri Error: "+message);
                     }
-    
+
                     let current = false;
                     if (message.current_states && Array.isArray(message.current_states)) {
                         current = true;
@@ -197,18 +190,27 @@ document.addEventListener('DOMContentLoaded', async () => {
                         current = false;
                     }
 
-                    if (message.type === "result" && current) {
+                    if (message.type === "result" && message.id === bpsSubscribeId && current) {
+                        starttrackbtn.style.display = "none";
+                        stoptrackbtn.style.display = "";
                         let floor = finalcords.floor.find(floor => floor.name === SelMapName);
                         message.current_states.forEach((entity, index) => {
                             updateEntArray(entity.entity_id, entity.state);
                         });
                         console.log("Registered array");
                         console.log(NewEnts);
-                    } else if (message.type === "result" && !message.success) {
+                    } else if (message.type === "result" && message.id === bpsSubscribeId && !message.success) {
                         console.log("Result Error: "+message);
                     }
                 };
-            };
+
+                socket.addEventListener("message", socketMessageHandler);
+                socket.send(JSON.stringify({
+                    id: bpsSubscribeId,
+                    type: "bps/subscribe",
+                    entities: tracked,
+                }));
+            });
 
         }
 
@@ -222,13 +224,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                 alert("There is no active connection");
                 return;
             }
+            socketIdCounter++;
             socket.send(JSON.stringify({
-                id: 2, // Unique ID for this message
+                id: socketIdCounter, // Unique ID for this message
                 type: "bps/unsubscribe",
                 entities: tracked,
             }));
-            socket.close();
+            if (socketMessageHandler) {
+                socket.removeEventListener("message", socketMessageHandler);
+                socketMessageHandler = null;
+            }
             socket = null;
+            bpsSubscribeId = null;
             console.log(`Unsubscribed`);
             starttrackbtn.style.display = "";
             stoptrackbtn.style.display = "none";

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -91,6 +91,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         let socket = null;
         let hassConnection = null;
+        let hassAuth = null;
         let socketMessageHandler = null;
         let bpsSubscribeId = null;
         const tracked = [];
@@ -111,6 +112,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             const connectionObject = await connectionPromise;
+            hassAuth = connectionObject.auth || hassAuth;
             hassConnection = connectionObject.conn || connectionObject;
 
             if (!hassConnection || !hassConnection.socket) {
@@ -118,6 +120,26 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             return hassConnection;
+        }
+
+        async function getHassAccessToken() {
+            if (!hassAuth) {
+                return null;
+            }
+
+            if (hassAuth.data && hassAuth.data.access_token) {
+                return hassAuth.data.access_token;
+            }
+
+            if (typeof hassAuth.accessToken === "function") {
+                return await hassAuth.accessToken();
+            }
+
+            if (hassAuth.accessToken) {
+                return hassAuth.accessToken;
+            }
+
+            return null;
         }
 
         function startTracking() {
@@ -153,63 +175,80 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return;
                 }
 
-                socket = conn.socket;
-                bpsSubscribeId = Date.now();
-                socketIdCounter = bpsSubscribeId;
-
-                socketMessageHandler = async (event) => {
-                    let message = null;
-                    try {
-                        message = JSON.parse(event.data);
-                    } catch (e) {
+                getHassAccessToken().then((accessToken) => {
+                    if (!accessToken) {
+                        alert("Could not access Home Assistant token.");
                         return;
                     }
 
-                    if (message.type === "state_changed") {
-                        await updateEntArray(message.entity_id, message.new_state);
-                        socketIdCounter++;
-                        const triData = NewEnts.map(item => item.cords);
-                        socket.send(JSON.stringify({
-                            id: socketIdCounter,
-                            type: "bps/known_points",
-                            knownPoints: triData,
-                        }));
-                    }
+                    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+                    socket = new WebSocket(`${wsProtocol}//${window.location.host}/api/websocket`);
+                    bpsSubscribeId = Date.now();
+                    socketIdCounter = bpsSubscribeId;
 
-                    // Handle the response from knownPoints
-                    if (message.type === "tri_result" && message.success) {
-                        drawTracker(message.result);
-                    } else if (message.type === "tri_result" && !message.success) {
-                        console.log("Tri Error: "+message);
-                    }
+                    socketMessageHandler = async (event) => {
+                        let message = null;
+                        try {
+                            message = JSON.parse(event.data);
+                        } catch (e) {
+                            return;
+                        }
 
-                    let current = false;
-                    if (message.current_states && Array.isArray(message.current_states)) {
-                        current = true;
-                    } else {
-                        current = false;
-                    }
+                        if (message.type === "auth_required") {
+                            socket.send(JSON.stringify({ type: "auth", access_token: accessToken }));
+                            return;
+                        }
 
-                    if (message.type === "result" && message.id === bpsSubscribeId && current) {
-                        starttrackbtn.style.display = "none";
-                        stoptrackbtn.style.display = "";
-                        let floor = finalcords.floor.find(floor => floor.name === SelMapName);
-                        message.current_states.forEach((entity, index) => {
-                            updateEntArray(entity.entity_id, entity.state);
-                        });
-                        console.log("Registered array");
-                        console.log(NewEnts);
-                    } else if (message.type === "result" && message.id === bpsSubscribeId && !message.success) {
-                        console.log("Result Error: "+message);
-                    }
-                };
+                        if (message.type === "auth_ok") {
+                            socket.send(JSON.stringify({
+                                id: bpsSubscribeId,
+                                type: "bps/subscribe",
+                                entities: tracked,
+                            }));
+                            return;
+                        }
 
-                socket.addEventListener("message", socketMessageHandler);
-                socket.send(JSON.stringify({
-                    id: bpsSubscribeId,
-                    type: "bps/subscribe",
-                    entities: tracked,
-                }));
+                        if (message.type === "state_changed") {
+                            await updateEntArray(message.entity_id, message.new_state);
+                            socketIdCounter++;
+                            const triData = NewEnts.map(item => item.cords);
+                            socket.send(JSON.stringify({
+                                id: socketIdCounter,
+                                type: "bps/known_points",
+                                knownPoints: triData,
+                            }));
+                        }
+
+                        // Handle the response from knownPoints
+                        if (message.type === "tri_result" && message.success) {
+                            drawTracker(message.result);
+                        } else if (message.type === "tri_result" && !message.success) {
+                            console.log("Tri Error: "+message);
+                        }
+
+                        let current = false;
+                        if (message.current_states && Array.isArray(message.current_states)) {
+                            current = true;
+                        } else {
+                            current = false;
+                        }
+
+                        if (message.type === "result" && message.id === bpsSubscribeId && current) {
+                            starttrackbtn.style.display = "none";
+                            stoptrackbtn.style.display = "";
+                            let floor = finalcords.floor.find(floor => floor.name === SelMapName);
+                            message.current_states.forEach((entity, index) => {
+                                updateEntArray(entity.entity_id, entity.state);
+                            });
+                            console.log("Registered array");
+                            console.log(NewEnts);
+                        } else if (message.type === "result" && message.id === bpsSubscribeId && !message.success) {
+                            console.log("Result Error: "+message);
+                        }
+                    };
+
+                    socket.addEventListener("message", socketMessageHandler);
+                });
             });
 
         }
@@ -234,6 +273,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 socket.removeEventListener("message", socketMessageHandler);
                 socketMessageHandler = null;
             }
+            socket.close();
             socket = null;
             bpsSubscribeId = null;
             console.log(`Unsubscribed`);

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -296,11 +296,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return;
                 }
                 let apiresponse = await fetchBPSCords();
+                if (!Array.isArray(apiresponse) || apiresponse.length === 0) {
+                    return;
+                }
                 let result = apiresponse.find(item => item.ent === device.replace("sensor.",""));
+                if (!result || !Array.isArray(result.cords) || result.cords.length < 2) {
+                    return;
+                }
                 let dt = {x: result.cords[0], y:result.cords[1]};
                 drawTracker(dt);
                 zonediv.style.display = "";
-                document.getElementById("zonevalue").textContent = result.zone;
+                document.getElementById("zonevalue").textContent = result.zone || "unknown";
             }, 500); // Run every half second
         }
 
@@ -420,7 +426,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         
             if (!response.ok) {
                 console.error("Failed to fetch BPS data:", response.statusText); // Handle error status
-                return;
+                return [];
             }
         
             const data = await response.json();
@@ -429,6 +435,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             } catch (error) {
             // Handle possible error during fetch-call
             console.error("Error fetching BPS data:", error);
+            return [];
             }
         }
 

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -1,10 +1,31 @@
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bps_sensors"
+
+
+def is_legacy_bps_entity_id(entity_id):
+    """Detect old duplicated-name entity IDs like sensor.name_name_bps_floor."""
+    if not entity_id.startswith("sensor.") or "_bps_" not in entity_id:
+        return False
+
+    if not (entity_id.endswith("_bps_floor") or entity_id.endswith("_bps_zone")):
+        return False
+
+    object_id = entity_id.replace("sensor.", "")
+    base_name = object_id.rsplit("_bps_", 1)[0]
+    parts = base_name.split("_")
+
+    # Legacy format duplicates the full object id: <name>_<name>
+    if len(parts) % 2 != 0:
+        return False
+
+    half = len(parts) // 2
+    return parts[:half] == parts[half:]
 
 def get_filtered_entities(hass):
     """Fetch and filter sensors based on their entity_id"""
@@ -35,12 +56,33 @@ class CustomDistanceSensor(SensorEntity):
     def state(self):
         return self._state
 
+def cleanup_legacy_bps_entities(hass):
+    """Remove old duplicated-name BPS entities from entity registry."""
+    entity_registry = er.async_get(hass)
+    stale_entities = [
+        entry.entity_id
+        for entry in entity_registry.entities.values()
+        if (
+            is_legacy_bps_entity_id(entry.entity_id)
+            and (
+                entry.platform == "bps"
+                or (entry.unique_id and entry.unique_id.startswith("bps_"))
+            )
+        )
+    ]
+
+    for entity_id in stale_entities:
+        _LOGGER.info("Removing legacy BPS entity: %s", entity_id)
+        entity_registry.async_remove(entity_id)
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set dynamic sensors based on the filtered entities"""
     _LOGGER.info("async_setup_entry in sensor.py has been called")
     
     if "bps_sensors" not in hass.data:
         hass.data["bps_sensors"] = {}
+
+    cleanup_legacy_bps_entities(hass)
 
     entities = get_filtered_entities(hass)
     _LOGGER.info(f"Creating sensors for entities: {entities}")

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -75,6 +75,16 @@ def cleanup_legacy_bps_entities(hass):
         _LOGGER.info("Removing legacy BPS entity: %s", entity_id)
         entity_registry.async_remove(entity_id)
 
+    # Also remove lingering legacy states that may still appear in Developer Tools.
+    legacy_state_ids = [
+        state.entity_id
+        for state in hass.states.async_all()
+        if is_legacy_bps_entity_id(state.entity_id)
+    ]
+    for entity_id in legacy_state_ids:
+        _LOGGER.info("Removing legacy BPS state: %s", entity_id)
+        hass.states.async_remove(entity_id)
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set dynamic sensors based on the filtered entities"""
     _LOGGER.info("async_setup_entry in sensor.py has been called")

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -54,12 +54,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         unique_floor_id = f"sensor.{entity}_bps_floor"
         unique_floor_uid = f"bps_floor_{entity}"
 
-        if not any(s.startswith(unique_zone_id) for s in existing_sensors):
+        zone_exists = (
+            any(s.startswith(unique_zone_id) for s in existing_sensors)
+            or unique_zone_id in hass.data["bps_sensors"]
+        )
+        if not zone_exists:
             sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid)
             hass.data["bps_sensors"][unique_zone_id] = sensor
             new_sensors.append(sensor)
 
-        if not any(s.startswith(unique_floor_id) for s in existing_sensors):
+        floor_exists = (
+            any(s.startswith(unique_floor_id) for s in existing_sensors)
+            or unique_floor_id in hass.data["bps_sensors"]
+        )
+        if not floor_exists:
             sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid)
             hass.data["bps_sensors"][unique_floor_id] = sensor
             new_sensors.append(sensor)
@@ -81,12 +89,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             unique_floor_id = f"sensor.{entity}_bps_floor"
             unique_floor_uid = f"bps_floor_{entity}"
 
-            if not any(s.startswith(unique_zone_id) for s in existing_sensors):
+            zone_exists = (
+                any(s.startswith(unique_zone_id) for s in existing_sensors)
+                or unique_zone_id in hass.data["bps_sensors"]
+            )
+            if not zone_exists:
                 sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid)
                 hass.data["bps_sensors"][unique_zone_id] = sensor
                 new_sensors.append(sensor)
 
-            if not any(s.startswith(unique_floor_id) for s in existing_sensors):
+            floor_exists = (
+                any(s.startswith(unique_floor_id) for s in existing_sensors)
+                or unique_floor_id in hass.data["bps_sensors"]
+            )
+            if not floor_exists:
                 sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid)
                 hass.data["bps_sensors"][unique_floor_id] = sensor
                 new_sensors.append(sensor)

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -87,7 +87,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entities = get_filtered_entities(hass)
     _LOGGER.info(f"Creating sensors for entities: {entities}")
 
-    existing_sensors = {state.entity_id for state in hass.states.async_all() if state.entity_id.startswith("sensor.")}
+    entity_registry = er.async_get(hass)
+    existing_sensors = {
+        entry.entity_id
+        for entry in entity_registry.entities.values()
+        if entry.platform == "bps"
+    }
 
     new_sensors = []
     for entity in entities:
@@ -123,7 +128,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         new_entities = get_filtered_entities(hass)
         new_sensors = []
 
-        existing_sensors = {state.entity_id for state in hass.states.async_all() if state.entity_id.startswith("sensor.")}
+        entity_registry = er.async_get(hass)
+        existing_sensors = {
+            entry.entity_id
+            for entry in entity_registry.entities.values()
+            if entry.platform == "bps"
+        }
 
         for entity in new_entities:
             unique_zone_id = f"sensor.{entity}_bps_zone"

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -39,10 +39,13 @@ def get_filtered_entities(hass):
 
 class CustomDistanceSensor(SensorEntity):
     """A representation of a custom sensor"""
-    def __init__(self, name, unique_id):
+    def __init__(self, name, unique_id, entity_id):
         self._name = name
         self._unique_id = unique_id
+        self._attr_name = name
+        self._attr_unique_id = unique_id
         self._state = "unknown"
+        self.entity_id = entity_id
     
     @property
     def name(self):
@@ -62,20 +65,18 @@ def cleanup_legacy_bps_entities(hass):
     stale_entities = [
         entry.entity_id
         for entry in entity_registry.entities.values()
-        if (
-            is_legacy_bps_entity_id(entry.entity_id)
-            and (
-                entry.platform == "bps"
-                or (entry.unique_id and entry.unique_id.startswith("bps_"))
-            )
-        )
+        if is_legacy_bps_entity_id(entry.entity_id)
     ]
 
     for entity_id in stale_entities:
         _LOGGER.info("Removing legacy BPS entity: %s", entity_id)
         entity_registry.async_remove(entity_id)
 
-    # Also remove lingering legacy states that may still appear in Developer Tools.
+    cleanup_legacy_bps_states(hass)
+
+
+def cleanup_legacy_bps_states(hass):
+    """Remove lingering legacy states from the state machine."""
     legacy_state_ids = [
         state.entity_id
         for state in hass.states.async_all()
@@ -84,6 +85,67 @@ def cleanup_legacy_bps_entities(hass):
     for entity_id in legacy_state_ids:
         _LOGGER.info("Removing legacy BPS state: %s", entity_id)
         hass.states.async_remove(entity_id)
+
+
+def normalize_bps_registry_entity_ids(hass, entities):
+    """Ensure BPS registry entries use stable non-legacy entity_id by unique_id."""
+    entity_registry = er.async_get(hass)
+    expected_by_uid = {}
+    for entity in entities:
+        expected_by_uid[f"bps_zone_{entity}"] = f"sensor.{entity}_bps_zone"
+        expected_by_uid[f"bps_floor_{entity}"] = f"sensor.{entity}_bps_floor"
+
+    for entry in list(entity_registry.entities.values()):
+        expected_entity_id = expected_by_uid.get(entry.unique_id)
+        if expected_entity_id and entry.entity_id != expected_entity_id:
+            _LOGGER.info(
+                "Migrating BPS entity_id from %s to %s",
+                entry.entity_id,
+                expected_entity_id,
+            )
+            try:
+                entity_registry.async_update_entity(
+                    entry.entity_id,
+                    new_entity_id=expected_entity_id,
+                )
+            except ValueError:
+                # If the target id is blocked by stale data/entry, remove old entry and recreate.
+                _LOGGER.info("Removing conflicting BPS registry entity: %s", entry.entity_id)
+                entity_registry.async_remove(entry.entity_id)
+
+
+def normalize_bps_registry_entity_ids_from_cache(hass):
+    """Normalize BPS entity_ids using the in-memory sensor cache unique_ids."""
+    sensors_cache = hass.data.get("bps_sensors", {})
+    if not sensors_cache:
+        return
+
+    expected_by_uid = {}
+    for expected_entity_id, sensor in sensors_cache.items():
+        uid = getattr(sensor, "unique_id", None)
+        if uid and expected_entity_id.startswith("sensor."):
+            expected_by_uid[uid] = expected_entity_id
+
+    if not expected_by_uid:
+        return
+
+    entity_registry = er.async_get(hass)
+    for entry in list(entity_registry.entities.values()):
+        expected_entity_id = expected_by_uid.get(entry.unique_id)
+        if expected_entity_id and entry.entity_id != expected_entity_id:
+            _LOGGER.info(
+                "Post-add migration of BPS entity_id from %s to %s",
+                entry.entity_id,
+                expected_entity_id,
+            )
+            try:
+                entity_registry.async_update_entity(
+                    entry.entity_id,
+                    new_entity_id=expected_entity_id,
+                )
+            except ValueError:
+                _LOGGER.info("Removing conflicting BPS registry entity: %s", entry.entity_id)
+                entity_registry.async_remove(entry.entity_id)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set dynamic sensors based on the filtered entities"""
@@ -96,8 +158,25 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = get_filtered_entities(hass)
     _LOGGER.info(f"Creating sensors for entities: {entities}")
+    normalize_bps_registry_entity_ids(hass, entities)
 
+    expected_entity_ids = set()
+    for entity in entities:
+        expected_entity_ids.add(f"sensor.{entity}_bps_zone")
+        expected_entity_ids.add(f"sensor.{entity}_bps_floor")
+
+    # Remove stale BPS registry entries that are no longer expected.
     entity_registry = er.async_get(hass)
+    if expected_entity_ids:
+        stale_bps_ids = [
+            entry.entity_id
+            for entry in entity_registry.entities.values()
+            if entry.platform == "bps" and entry.entity_id not in expected_entity_ids
+        ]
+        for entity_id in stale_bps_ids:
+            _LOGGER.info("Removing stale BPS registry entity: %s", entity_id)
+            entity_registry.async_remove(entity_id)
+
     existing_sensors = {
         entry.entity_id
         for entry in entity_registry.entities.values()
@@ -116,7 +195,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             or unique_zone_id in hass.data["bps_sensors"]
         )
         if not zone_exists:
-            sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid)
+            sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid, unique_zone_id)
             hass.data["bps_sensors"][unique_zone_id] = sensor
             new_sensors.append(sensor)
 
@@ -125,16 +204,22 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             or unique_floor_id in hass.data["bps_sensors"]
         )
         if not floor_exists:
-            sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid)
+            sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid, unique_floor_id)
             hass.data["bps_sensors"][unique_floor_id] = sensor
             new_sensors.append(sensor)
 
     if new_sensors:
         async_add_entities(new_sensors, update_before_add=True)
+        normalize_bps_registry_entity_ids_from_cache(hass)
 
     @callback
     def state_changed_listener(event):
         """Listen for state changes to update dynamic sensors"""
+        sensors_cache = hass.data.get("bps_sensors")
+        if sensors_cache is None:
+            # Integration is unloading/reloading; ignore late state events.
+            return
+
         new_entities = get_filtered_entities(hass)
         new_sensors = []
 
@@ -153,26 +238,30 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             zone_exists = (
                 any(s.startswith(unique_zone_id) for s in existing_sensors)
-                or unique_zone_id in hass.data["bps_sensors"]
+                or unique_zone_id in sensors_cache
             )
             if not zone_exists:
-                sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid)
-                hass.data["bps_sensors"][unique_zone_id] = sensor
+                sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid, unique_zone_id)
+                sensors_cache[unique_zone_id] = sensor
                 new_sensors.append(sensor)
 
             floor_exists = (
                 any(s.startswith(unique_floor_id) for s in existing_sensors)
-                or unique_floor_id in hass.data["bps_sensors"]
+                or unique_floor_id in sensors_cache
             )
             if not floor_exists:
-                sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid)
-                hass.data["bps_sensors"][unique_floor_id] = sensor
+                sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid, unique_floor_id)
+                sensors_cache[unique_floor_id] = sensor
                 new_sensors.append(sensor)
 
         if new_sensors:
             async_add_entities(new_sensors, update_before_add=True)
+            normalize_bps_registry_entity_ids_from_cache(hass)
 
-    hass.bus.async_listen("state_changed", state_changed_listener)
+    old_unsub = hass.data.pop("bps_state_listener_unsub", None)
+    if old_unsub:
+        old_unsub()
+    hass.data["bps_state_listener_unsub"] = hass.bus.async_listen("state_changed", state_changed_listener)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):


### PR DESCRIPTION
## Summary
- harden integration lifecycle and cleanup behavior to avoid stale/duplicated entities, unavailable sensors, and reload instability
- fix sensor ID normalization and legacy migration paths so BPS entities remain stable and visible in Home Assistant
- add zone improvements (duplicate zone names via internal IDs) and custom tracker icon support with upload + per-tracker persistence

## Test plan
- [x] Reproduced and fixed duplicate/legacy entity ID behavior during install/reload
- [x] Verified entities are available in integration view and states update correctly
- [x] Verified zone matching improvements and duplicate zone names on the same floor
- [x] Verified custom tracker icon upload/selection and persistence after save/reload
- [x] Verified no new local uncommitted changes after commits

Made with [Cursor](https://cursor.com)